### PR TITLE
Check allowed against uri without port

### DIFF
--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -77,6 +77,7 @@ module WebMock
       (uri.omit(:port).to_s =~ allowed) != nil && uri.port == uri.default_port
     when String
       allowed == uri.to_s ||
+      allowed == uri.omit(:port).to_s ||
       allowed == uri.host ||
       allowed == "#{uri.host}:#{uri.port}" ||
       allowed == "#{uri.scheme}://#{uri.host}:#{uri.port}" ||


### PR DESCRIPTION
I ran into this issue when using the [`webdrivers`][1] gem with WebMock.
WebMock reported the error below:

```
WebMock::NetConnectNotAllowedError:
  Real HTTP connections are disabled. Unregistered request: GET https://github.com/mozilla/geckodriver/releases/latest with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'github.com', 'User-Agent'=>'Ruby'}

  You can stub this request with the following snippet:

  stub_request(:get, "https://github.com/mozilla/geckodriver/releases/latest").
    with(
      headers: {
	'Accept'=>'*/*',
	'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
	'Host'=>'github.com',
	'User-Agent'=>'Ruby'
      }).
    to_return(status: 200, body: "", headers: {})

  ============================================================
```

I tried to add the URL mentioned using `allow:`:

```rb
WebMock.disable_net_connect!(
  allow_localhost: true,
  allow: ["https://github.com/mozilla/geckodriver/releases/latest"],
)
```

However, it continued to report the same error. I dug into WebMock, and it
turns out the request was actually being made to:

```
https://github.com:443/mozilla/geckodriver/releases/latest
\# note the port  ^^^^
```

This seems like pretty confusing behavior, so maybe WebMock should either print
the port in the output, or check `allowed` without the port. Not sure if my
thinking is right on this, but I thought it would be fine to add an additional
check without the port, so that's what we have here.

[1]: https://github.com/titusfortner/webdrivers